### PR TITLE
RM 6639: Adaptation for Emcraft 'project' build procedure

### DIFF
--- a/arch/arm/Makefile
+++ b/arch/arm/Makefile
@@ -300,7 +300,12 @@ INSTALL_TARGETS	= zinstall uinstall install
 
 PHONY += bzImage $(BOOT_TARGETS) $(INSTALL_TARGETS)
 
+ifeq ($(CONFIG_KERNEL_COMPRESS_NONE),y)
+bootpImage uImage: Image
+else
 bootpImage uImage: zImage
+endif
+
 zImage: Image
 
 $(BOOT_TARGETS): vmlinux

--- a/arch/arm/boot/Makefile
+++ b/arch/arm/boot/Makefile
@@ -63,8 +63,14 @@ $(obj)/Image: vmlinux FORCE
 $(obj)/compressed/vmlinux: $(obj)/Image FORCE
 	$(Q)$(MAKE) $(build)=$(obj)/compressed $@
 
+ifeq ($(CONFIG_KERNEL_COMPRESS_NONE),y)
+$(obj)/zImage: FORCE
+	@$(kecho) 'Kernel configured for no compression (CONFIG_COMPRESS_NONE=y)'
+	@false
+else
 $(obj)/zImage:	$(obj)/compressed/vmlinux FORCE
 	$(call if_changed,objcopy)
+endif
 
 endif
 
@@ -86,9 +92,14 @@ if [ $(words $(UIMAGE_LOADADDR)) -ne 1 ]; then \
 	false; \
 fi
 
+ifeq ($(CONFIG_KERNEL_COMPRESS_NONE),y)
+$(obj)/uImage:	$(obj)/Image FORCE
+	$(call if_changed,uimage)
+else
 $(obj)/uImage:	$(obj)/zImage FORCE
 	@$(check_for_multiple_loadaddr)
 	$(call if_changed,uimage)
+endif
 
 $(obj)/bootp/bootp: $(obj)/zImage initrd FORCE
 	$(Q)$(MAKE) $(build)=$(obj)/bootp $@

--- a/arch/arm/boot/Makefile
+++ b/arch/arm/boot/Makefile
@@ -84,6 +84,20 @@ else
   endif
 endif
 
+ifeq ($(UIMAGE_LOADADDR),)
+  UIMAGE_LOADADDR=$(shell /bin/bash -c 'printf "0x%08x" \
+					$$[$(CONFIG_DRAM_BASE) + 0x008000]')
+endif
+
+ifeq ($(UIMAGE_ENTRYADDR),)
+  ifeq ($(CONFIG_THUMB2_KERNEL),y)
+    # Set bit 0 to 1 so that "mov pc, rx" switches to Thumb-2 mode
+    UIMAGE_ENTRYADDR?=$(shell echo $(UIMAGE_LOADADDR) | sed -e "s/.$$/1/")
+  else
+    UIMAGE_ENTRYADDR?=$(UIMAGE_LOADADDR)
+  endif
+endif
+
 check_for_multiple_loadaddr = \
 if [ $(words $(UIMAGE_LOADADDR)) -ne 1 ]; then \
 	echo 'multiple (or no) load addresses: $(UIMAGE_LOADADDR)'; \

--- a/arch/arm/kernel/vmlinux.lds.S.good
+++ b/arch/arm/kernel/vmlinux.lds.S.good
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* ld script to make ARM Linux kernel
+ * taken from the i386 version by Russell King
+ * Written by Martin Mares <mj@atrey.karlin.mff.cuni.cz>
+ */
+
+#ifdef CONFIG_XIP_KERNEL
+#include "vmlinux-xip.lds.S"
+#else
+
+#include <linux/pgtable.h>
+#include <asm/vmlinux.lds.h>
+#include <asm/cache.h>
+#include <asm/thread_info.h>
+#include <asm/memory.h>
+#include <asm/mpu.h>
+#include <asm/page.h>
+
+OUTPUT_ARCH(arm)
+ENTRY(stext)
+
+#ifndef __ARMEB__
+jiffies = jiffies_64;
+#else
+jiffies = jiffies_64 + 4;
+#endif
+
+SECTIONS
+{
+	/*
+	 * XXX: The linker does not define how output sections are
+	 * assigned to input sections when there are multiple statements
+	 * matching the same input section name.  There is no documented
+	 * order of matching.
+	 *
+	 * unwind exit sections must be discarded before the rest of the
+	 * unwind sections get included.
+	 */
+	/DISCARD/ : {
+		ARM_DISCARD
+#ifndef CONFIG_SMP_ON_UP
+		*(.alt.smp.init)
+#endif
+#ifndef CONFIG_ARM_UNWIND
+		*(.ARM.exidx) *(.ARM.exidx.*)
+		*(.ARM.extab) *(.ARM.extab.*)
+#endif
+	}
+
+	. = KERNEL_OFFSET + TEXT_OFFSET;
+	.head.text : {
+		_text = .;
+		HEAD_TEXT
+	}
+
+#ifdef CONFIG_STRICT_KERNEL_RWX
+	. = ALIGN(1<<SECTION_SHIFT);
+#endif
+
+#ifdef CONFIG_ARM_MPU
+	. = ALIGN(PMSAv8_MINALIGN);
+#endif
+	.text : {			/* Real text segment		*/
+		_stext = .;		/* Text and read-only data	*/
+		ARM_TEXT
+	}
+
+#ifdef CONFIG_DEBUG_ALIGN_RODATA
+	. = ALIGN(1<<SECTION_SHIFT);
+#endif
+	_etext = .;			/* End of text section */
+
+	RO_DATA(PAGE_SIZE)
+
+	. = ALIGN(4);
+	__ex_table : AT(ADDR(__ex_table) - LOAD_OFFSET) {
+		__start___ex_table = .;
+		ARM_MMU_KEEP(*(__ex_table))
+		__stop___ex_table = .;
+	}
+
+#ifdef CONFIG_ARM_UNWIND
+	ARM_UNWIND_SECTIONS
+#endif
+
+#ifdef CONFIG_STRICT_KERNEL_RWX
+	. = ALIGN(1<<SECTION_SHIFT);
+#else
+	. = ALIGN(PAGE_SIZE);
+#endif
+	__init_begin = .;
+
+	ARM_VECTORS
+	INIT_TEXT_SECTION(8)
+	.exit.text : {
+		ARM_EXIT_KEEP(EXIT_TEXT)
+	}
+	.init.proc.info : {
+		ARM_CPU_DISCARD(PROC_INFO)
+	}
+	.init.arch.info : {
+		__arch_info_begin = .;
+		*(.arch.info.init)
+		__arch_info_end = .;
+	}
+	.init.tagtable : {
+		__tagtable_begin = .;
+		*(.taglist.init)
+		__tagtable_end = .;
+	}
+#ifdef CONFIG_SMP_ON_UP
+	.init.smpalt : {
+		__smpalt_begin = .;
+		*(.alt.smp.init)
+		__smpalt_end = .;
+	}
+#endif
+	.init.pv_table : {
+		__pv_table_begin = .;
+		*(.pv_table)
+		__pv_table_end = .;
+	}
+
+	INIT_DATA_SECTION(16)
+
+	.exit.data : {
+		ARM_EXIT_KEEP(EXIT_DATA)
+	}
+
+#ifdef CONFIG_SMP
+	PERCPU_SECTION(L1_CACHE_BYTES)
+#endif
+
+#ifdef CONFIG_HAVE_TCM
+	ARM_TCM
+#endif
+
+#ifdef CONFIG_STRICT_KERNEL_RWX
+	. = ALIGN(1<<SECTION_SHIFT);
+#else
+	. = ALIGN(THREAD_SIZE);
+#endif
+	__init_end = .;
+
+	_sdata = .;
+	RW_DATA(L1_CACHE_BYTES, PAGE_SIZE, THREAD_SIZE)
+	_edata = .;
+
+	BSS_SECTION(0, 0, 0)
+#ifdef CONFIG_ARM_MPU
+	. = ALIGN(PMSAv8_MINALIGN);
+#endif
+	_end = .;
+
+	STABS_DEBUG
+	DWARF_DEBUG
+	ARM_DETAILS
+
+	ARM_ASSERTS
+}
+
+#ifdef CONFIG_STRICT_KERNEL_RWX
+/*
+ * Without CONFIG_DEBUG_ALIGN_RODATA, __start_rodata_section_aligned will
+ * be the first section-aligned location after __start_rodata. Otherwise,
+ * it will be equal to __start_rodata.
+ */
+__start_rodata_section_aligned = ALIGN(__start_rodata, 1 << SECTION_SHIFT);
+#endif
+
+/*
+ * These must never be empty
+ * If you have to comment these two assert statements out, your
+ * binutils is too old (for other reasons as well)
+ */
+ASSERT((__proc_info_end - __proc_info_begin), "missing CPU support")
+ASSERT((__arch_info_end - __arch_info_begin), "no machine record defined")
+
+#endif /* CONFIG_XIP_KERNEL */

--- a/init/Kconfig
+++ b/init/Kconfig
@@ -300,6 +300,11 @@ config KERNEL_LZO
 	  size is about 10% bigger than gzip; however its speed
 	  (both compression and decompression) is the fastest.
 
+config KERNEL_COMPRESS_NONE
+	bool "NONE"
+	help
+	  No compression of the kernel image. Fastest decompression time.
+
 config KERNEL_LZ4
 	bool "LZ4"
 	depends on HAVE_KERNEL_LZ4

--- a/initramfs-list-min.stub
+++ b/initramfs-list-min.stub
@@ -1,0 +1,6 @@
+# This is a stub initramfs.
+# We need it in order to build a stub initramfs, so
+# as to complete a kernel build successfully, before
+# we can run build and installation of kernel modules.
+
+dir /dev 0755 0 0

--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -425,13 +425,14 @@ UIMAGE_TYPE ?= kernel
 UIMAGE_LOADADDR ?= arch_must_set_this
 UIMAGE_ENTRYADDR ?= $(UIMAGE_LOADADDR)
 UIMAGE_NAME ?= 'Linux-$(KERNELRELEASE)'
+UIMAGE_IN ?= $<
 
 quiet_cmd_uimage = UIMAGE  $@
       cmd_uimage = $(BASH) $(MKIMAGE) -A $(UIMAGE_ARCH) -O linux \
 			-C $(UIMAGE_COMPRESSION) $(UIMAGE_OPTS-y) \
 			-T $(UIMAGE_TYPE) \
 			-a $(UIMAGE_LOADADDR) -e $(UIMAGE_ENTRYADDR) \
-			-n $(UIMAGE_NAME) -d $< $@
+			-n $(UIMAGE_NAME) -d $(UIMAGE_IN) $@
 
 # XZ
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Design

A number of changes is required to build the kernel using the Emcraft 'projects' framework. Some of them were ported from the Emcraft 4.5 kernel:

1. Support uncompressed kernel feature (CONFIG_KERNEL_COMPRESS_NONE)
2. Create vmlinux.lds.S.good backup file
3. Create the initramfs-list-min.stub file. We need it in order to build a stub initramfs, so as to complete a kernel build successfully, before we can run build and installation of kernel modules.
4. Set UIMAGE_LOADADDR from .config
5. Correct UIMAGE_ENTRYADDR for thumb2-only kernel
6. Restore UIMAGE_IN env variable to pass the uImage data files from the Emcraft 'project' build procedure (it was removed from the mainline kernel some time ago)

### Test

1. On the Linux host, activate the build environment:
```
$ . ACTIVATE.sh
```
2. Build the rootfs project:
```
$ cd projects/rootfs
$ make
...
$ ls -l rootfs.uImage
-rw-rw-r--. 1 sasha_d sasha_d 4950317 May 24 16:29 rootfs.uImage
$
```
3. Copy the rootfs.uImage file to the TFTP server.
4. Boot the kernel image over Ethernet and verify that the kernel and the command shell starts successfully:
```
STM32H7-SOM U-Boot > setenv image stm32h7/rootfs.uImage
STM32H7-SOM U-Boot > run netboot
ethernet@40028000 Waiting for PHY auto negotiation to complete. done
Using ethernet@40028000 device
TFTP from server 192.168.0.3; our IP address is 192.168.0.166
Filename 'stm32h7/rootfs.uImage'.
Load address: 0xd0400000
Loading: #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #############
         354.5 KiB/s
done
Bytes transferred = 4950317 (4b892d hex)
## Booting kernel from Legacy Image at d0400000 ...
   Image Name:   Linux-5.15.67-00004-g70c36e17f0b
   Image Type:   ARM Linux Multi-File Image (uncompressed)
   Data Size:    4950253 Bytes = 4.7 MiB
   Load Address: d0008000
   Entry Point:  d0008001
   Contents:
      Image 0: 4935776 Bytes = 4.7 MiB
      Image 1: 14465 Bytes = 14.1 KiB
   Verifying Checksum ... OK
## Loading init Ramdisk from multi component Legacy Image at d0400000 ...
## Flattened Device Tree from multi component Image at D0400000
   Booting using the fdt at 0xd08b50ac
   Loading Multi-File Image ... OK
WARNING: legacy format multi component image overwritten
   Loading Ramdisk to d1e71000, end d1e74881 ... OK
   Loading Device Tree to d1e6a000, end d1e70880 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0
[    0.000000] Linux version 5.15.67-00004-g70c36e17f0bc (sasha_d@workbench.emcraft.com) (arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10.3-2021.10) 10.3.1 20210824 (release), GNU ld (GNU Arm Embedded Toolchain 10.3-2021.10) 2.36.1.20210621) #150 PREEMPT Tue May 23 23:22:01 MSK 2023
[    0.000000] CPU: ARMv7-M [411fc271] revision 1 (ARMv7M), cr=00000000
[    0.000000] CPU: PIPT / VIPT nonaliasing data cache, PIPT instruction cache
[    0.000000] OF: fdt: Machine model: STM32H7 SOM Starter Kit
[    0.000000] printk: bootconsole [earlycon0] enabled
[    0.000000] printk: debug: ignoring loglevel setting.
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x00000000d0000000-0x00000000d1ffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x00000000d0000000-0x00000000d1ffffff]
[    0.000000] Initmem setup node 0 [mem 0x00000000d0000000-0x00000000d1ffffff]
[    0.000000] pcpu-alloc: s0 r0 d32768 u32768 alloc=1*32768
[    0.000000] pcpu-alloc: [0] 0
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 8128
[    0.000000] Kernel command line: console=ttySTM0,115200 earlyprintk consoleblank=0 panic=3 ignore_loglevel
...
init started: BusyBox v1.24.2 (2023-05-19 20:14:28 MSK)
mount: mounting devpts on /dev/pts failed: No such device
ifconfig: socket: Function not implemented
/ #
```
1. Run some basic commands from the shell:
```
/ # ls -l /
drwxr-xr-x    2 root     root             0 Jan  1 00:00 bin
drwxr-xr-x    3 root     root             0 Jan  1 00:00 dev
drwxr-xr-x    5 root     root             0 May 23  2023 etc
drwxr-xr-x    3 root     root             0 May 23  2023 httpd
lrwxrwxrwx    1 root     root             9 May 23  2023 init -> /bin/init
drwxrwxrwx    3 root     root             0 May 23  2023 lib
drwxrwxrwx    8 root     root             0 May 23  2023 mnt
dr-xr-xr-x   61 root     root             0 Jan  1 00:00 proc
drwx------    2 root     root             0 May 23  2023 root
drwxr-xr-x    2 root     root             0 Jan  1 00:00 sbin
dr-xr-xr-x   12 root     root             0 Jan  1 00:00 sys
drwxrwxrwx    2 root     root             0 May 23  2023 tmp
drwxr-xr-x    6 root     root             0 May 23  2023 usr
drwxr-xr-x    7 root     root             0 May 23  2023 var
/ # reboot
The system is going down NOW!
TERM
Sent SIGTERM to all processes
Sent SIGKILL to all processes
Requesting system reboot
[   75.362781] reboot: Res
U-Boot SPL 2019.04-00060-g87d66feb7b (May 02 2023 - 19:13:37 +0300)
```