### PR TITLE
RM 6641: Temporary implementation of dma_alloc_coherent() on STM32H7 SOM

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -173,6 +173,12 @@ int stmmac_bus_clks_config(struct stmmac_priv *priv, bool enabled)
 }
 EXPORT_SYMBOL_GPL(stmmac_bus_clks_config);
 
+/* temporary implementation of dma_alloc_coherent() on STM32H7 SOM */
+#define STM32H7_SOM_DMA
+#ifdef STM32H7_SOM_DMA
+static const char dma_rx_phy[16384] __attribute__ ((aligned (16)));
+static const char dma_tx_phy[16384] __attribute__ ((aligned (16)));
+#endif
 /**
  * stmmac_verify_args - verify the driver parameters.
  * Description: it checks the driver parameters and set a default in case of
@@ -1908,6 +1914,7 @@ static void __free_dma_rx_desc_resources(struct stmmac_priv *priv, u32 queue)
 	rx_q->buf_alloc_num = 0;
 	rx_q->xsk_pool = NULL;
 
+#ifndef STM32H7_SOM_DMA
 	/* Free DMA regions of consistent memory previously allocated */
 	if (!priv->extend_desc)
 		dma_free_coherent(priv->device, priv->dma_rx_size *
@@ -1917,6 +1924,7 @@ static void __free_dma_rx_desc_resources(struct stmmac_priv *priv, u32 queue)
 		dma_free_coherent(priv->device, priv->dma_rx_size *
 				  sizeof(struct dma_extended_desc),
 				  rx_q->dma_erx, rx_q->dma_rx_phy);
+#endif
 
 	if (xdp_rxq_info_is_reg(&rx_q->xdp_rxq))
 		xdp_rxq_info_unreg(&rx_q->xdp_rxq);
@@ -1963,7 +1971,9 @@ static void __free_dma_tx_desc_resources(struct stmmac_priv *priv, u32 queue)
 
 	size *= priv->dma_tx_size;
 
+#ifndef STM32H7_SOM_DMA
 	dma_free_coherent(priv->device, size, addr, tx_q->dma_tx_phy);
+#endif
 
 	kfree(tx_q->tx_skbuff_dma);
 	kfree(tx_q->tx_skbuff);
@@ -2025,6 +2035,12 @@ static int __alloc_dma_rx_desc_resources(struct stmmac_priv *priv, u32 queue)
 		return -ENOMEM;
 
 	if (priv->extend_desc) {
+#ifdef STM32H7_SOM_DMA
+		rx_q->dma_erx = (void*) dma_rx_phy;
+		rx_q->dma_rx_phy = (dma_addr_t) dma_rx_phy;
+		if ((u32)dma_rx_phy > 0xd03f0000)
+			return -ENOMEM;
+#else
 		rx_q->dma_erx = dma_alloc_coherent(priv->device,
 						   priv->dma_rx_size *
 						   sizeof(struct dma_extended_desc),
@@ -2032,8 +2048,15 @@ static int __alloc_dma_rx_desc_resources(struct stmmac_priv *priv, u32 queue)
 						   GFP_KERNEL);
 		if (!rx_q->dma_erx)
 			return -ENOMEM;
+#endif
 
 	} else {
+#ifdef STM32H7_SOM_DMA
+		rx_q->dma_rx = (void*) dma_rx_phy;
+		rx_q->dma_rx_phy = (dma_addr_t) dma_rx_phy;
+		if ((u32)dma_rx_phy > 0xd03f0000)
+			return -ENOMEM;
+#else
 		rx_q->dma_rx = dma_alloc_coherent(priv->device,
 						  priv->dma_rx_size *
 						  sizeof(struct dma_desc),
@@ -2041,6 +2064,7 @@ static int __alloc_dma_rx_desc_resources(struct stmmac_priv *priv, u32 queue)
 						  GFP_KERNEL);
 		if (!rx_q->dma_rx)
 			return -ENOMEM;
+#endif
 	}
 
 	if (stmmac_xdp_is_enabled(priv) &&
@@ -2120,10 +2144,17 @@ static int __alloc_dma_tx_desc_resources(struct stmmac_priv *priv, u32 queue)
 
 	size *= priv->dma_tx_size;
 
+#ifdef STM32H7_SOM_DMA
+	addr = (void*) dma_tx_phy;
+	tx_q->dma_tx_phy = (dma_addr_t) dma_tx_phy;
+	if ((u32)dma_tx_phy > 0xd03f0000)
+		return -ENOMEM;
+#else
 	addr = dma_alloc_coherent(priv->device, size,
 				  &tx_q->dma_tx_phy, GFP_KERNEL);
 	if (!addr)
 		return -ENOMEM;
+#endif
 
 	if (priv->extend_desc)
 		tx_q->dma_etx = addr;


### PR DESCRIPTION
### Design

Temporary implementation of dma_alloc_coherent() on STM32H7 SOM. We just create a static const array in hope that it will be placed in the text section and will be below the 4MB boundary in SDRAM, which is configured as uncached memory in U-Boot.  This hack is needed to start using Ethernet as soon as possible. The proper implementation is coming soon.

### Test

Configure the eth0 interface and ping the TFTP server:

```
/ # ifconfig eth0 192.168.0.166
[   31.905726] stm32-dwmac 40028000.ethernet eth0: PHY [stmmac-0:01] driver [SMSC LAN8710/LAN8720] (irq=POLL)
[   31.917970] stm32-dwmac 40028000.ethernet eth0: Register MEM_TYPE_PAGE_POOL RxQ-0
[   31.978994] stm32-dwmac 40028000.ethernet eth0: No Safety Features support found
[   31.988001] stm32-dwmac 40028000.ethernet eth0: IEEE 1588-2008 Advanced Timestamp supported
[   32.000476] stm32-dwmac 40028000.ethernet eth0: registered PTP clock
[   32.018187] stm32-dwmac 40028000.ethernet eth0: configuring for phy/rmii link mode
/ # [   34.132361] stm32-dwmac 40028000.ethernet eth0: Link is Up - 100Mbps/Full - flow control rx/tx
[   34.140412] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready

/ # ping 192.168.0.1
PING 192.168.0.1 (192.168.0.1): 56 data bytes
64 bytes from 192.168.0.1: seq=0 ttl=64 time=3.936 ms
64 bytes from 192.168.0.1: seq=1 ttl=64 time=1.896 ms
64 bytes from 192.168.0.1: seq=2 ttl=64 time=1.937 ms
^C
--- 192.168.0.1 ping statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 1.896/2.589/3.936 ms
/ #
```