### PR TITLE
RM 6754: Add a new SoC - STM32H753

### DIFF
--- a/arch/arm/mach-stm32/board-dt.c
+++ b/arch/arm/mach-stm32/board-dt.c
@@ -18,6 +18,7 @@ static const char *const stm32_compat[] __initconst = {
 	"st,stm32f769",
 	"st,stm32h743",
 	"st,stm32h750",
+	"st,stm32h753",
 	"st,stm32mp131",
 	"st,stm32mp133",
 	"st,stm32mp135",


### PR DESCRIPTION
### Design

Need to add "st,stm32h753" to the list of compatible strings

### Test

Refer to https://gitlab.com/emcraft/STM32H7/u-boot-upstream/-/merge_requests/15