### PR TITLE
RM-2901: Added support for the ARMv7-M VFP Extension

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -1969,6 +1969,13 @@ config KERNEL_MODE_NEON
 	help
 	  Say Y to include support for NEON in kernel mode.
 
+config VFPM
+	bool "ARMv7-M VFP Extension support"
+	depends on CPU_V7M
+	help
+	  Say Y to include support for the ARMv7-M VFP Extension
+	  (single-precision floating point hardware).
+
 endmenu
 
 menu "Power management options"

--- a/arch/arm/include/asm/fpstate.h
+++ b/arch/arm/include/asm/fpstate.h
@@ -40,6 +40,10 @@ struct vfp_hard_struct {
 #ifdef CONFIG_SMP
 	__u32 cpu;
 #endif
+
+#ifdef CONFIG_VFPM
+	__u32 used;
+#endif
 };
 
 union vfp_state {

--- a/arch/arm/kernel/Makefile
+++ b/arch/arm/kernel/Makefile
@@ -33,7 +33,7 @@ obj-$(CONFIG_ATAGS_PROC)	+= atags_proc.o
 obj-$(CONFIG_DEPRECATED_PARAM_STRUCT) += atags_compat.o
 
 ifeq ($(CONFIG_CPU_V7M),y)
-obj-y		+= entry-v7m.o v7m.o
+obj-y		+= entry-v7m.o v7m.o traps-v7m.o
 else
 obj-y		+= entry-armv.o
 endif
@@ -87,6 +87,11 @@ obj-$(CONFIG_ARM_CPU_TOPOLOGY)  += topology.o
 obj-$(CONFIG_VDSO)		+= vdso.o
 obj-$(CONFIG_EFI)		+= efi.o
 obj-$(CONFIG_PARAVIRT)	+= paravirt.o
+obj-$(CONFIG_VFPM)		+= vfp-m.o
+ifeq ($(CONFIG_VFPM),y)
+# -mfpu is already set by the upper level Makefile
+CFLAGS_vfp-m.o			:= -mfloat-abi=softfp
+endif
 
 head-y			:= head$(MMUEXT).o
 obj-$(CONFIG_DEBUG_LL)	+= debug.o

--- a/arch/arm/kernel/entry-v7m.S
+++ b/arch/arm/kernel/entry-v7m.S
@@ -32,6 +32,53 @@ ENDPROC(__invalid_entry)
 
 strerr:	.asciz	"\nUnhandled exception: IPSR = %08lx LR = %08lx\n"
 
+	.align  2
+__hardfault_entry:
+	v7m_exception_entry
+
+	@
+	@ Invoke the Hard Fault handler
+	@ routine called with r0 = struct pt_regs *
+	mov     r0, sp
+	bl      do_hardfault
+
+	@ execute the pending work, including reschedule
+	get_thread_info tsk
+	mov     why, #0
+	b       ret_to_user
+ENDPROC(__hardfault_entry)
+
+	.align  2
+__busfault_entry:
+	v7m_exception_entry
+
+	@
+	@ Invoke the Bus Fault handler
+	@ routine called with r0 = struct pt_regs *
+	mov     r0, sp
+	bl      do_busfault
+
+	@ execute the pending work, including reschedule
+	get_thread_info tsk
+	mov     why, #0
+	b       ret_to_user
+ENDPROC(__busfault_entry)
+
+	.align  2
+__usagefault_entry:
+	v7m_exception_entry
+
+	@
+	@ Invoke the Bus Fault handler
+	@ routine called with r0 = struct pt_regs *
+	mov     r0, sp
+	bl      do_usagefault
+
+	@ execute the pending work, including reschedule
+	get_thread_info tsk
+	mov     why, #0
+	b       ret_to_user
+ENDPROC(__usagefault_entry)
 	.align	2
 __irq_entry:
 	v7m_exception_entry
@@ -127,10 +174,10 @@ ENTRY(vector_table)
 	.long	0			@ 0 - Reset stack pointer
 	.long	__invalid_entry		@ 1 - Reset
 	.long	__invalid_entry		@ 2 - NMI
-	.long	__invalid_entry		@ 3 - HardFault
+	.long	__hardfault_entry	@ 3 - HardFault
 	.long	__invalid_entry		@ 4 - MemManage
-	.long	__invalid_entry		@ 5 - BusFault
-	.long	__invalid_entry		@ 6 - UsageFault
+	.long	__busfault_entry	@ 5 - BusFault
+	.long	__usagefault_entry	@ 6 - UsageFault
 	.long	__invalid_entry		@ 7 - Reserved
 	.long	__invalid_entry		@ 8 - Reserved
 	.long	__invalid_entry		@ 9 - Reserved

--- a/arch/arm/kernel/traps-v7m.c
+++ b/arch/arm/kernel/traps-v7m.c
@@ -1,0 +1,240 @@
+/*
+ * linux/arch/arm/kernel/traps-v7m.c
+ *
+ * Copyright (C) 2011 Dmitry Cherukhin, Emcraft Systems
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <linux/module.h>
+#include <linux/sched.h>
+#include <linux/mm.h>
+#include <linux/pagemap.h>
+#include <linux/io.h>
+
+#include <asm/cacheflush.h>
+#include <asm/sections.h>
+#include <asm/page.h>
+#include <asm/setup.h>
+#include <asm/mpu.h>
+#include <asm/mach/arch.h>
+#include <asm/system_misc.h>
+#include <asm/exception.h>
+
+struct nvic_regs {
+	unsigned long	some_regs1[837];	/* +000 */
+	unsigned long	config_control;		/* +d14 */
+	unsigned long	some_regs2[3];		/* +d18 */
+	unsigned long	system_handler_csr;	/* +d24 */
+	unsigned long	local_fault_status;	/* +d28 */
+	unsigned long	hard_fault_status;	/* +d2c */
+	unsigned long	some_regs3[1];		/* +d30 */
+	unsigned long	mfar;			/* +d34 */
+	unsigned long	bfar;			/* +d38 */
+	unsigned long	some_regs4[21];		/* +d3c */
+	unsigned long	mpu_type;               /* +d90 */
+	unsigned long	mpu_control;		/* +d94 */
+	unsigned long	reg_number;		/* +d98 */
+	unsigned long	reg_base;		/* +d9c */
+	unsigned long	reg_attr;		/* +da0 */
+};
+
+#define NVIC_REGS_BASE  0xE000E000
+#define NVIC		((struct nvic_regs *)(NVIC_REGS_BASE))
+
+enum config_control_bits {
+	UNALIGN_TRP	= 0x00000008,
+	DIV_0_TRP	= 0x00000010,
+};
+
+enum system_handler_csr_bits {
+	BUSFAULTENA	= 0x00020000,
+	USGFAULTENA	= 0x00040000,
+};
+
+enum local_fault_status_bits {
+	IBUSERR		= 0x00000100,
+	PRECISERR	= 0x00000200,
+	IMPRECISERR	= 0x00000400,
+	UNSTKERR	= 0x00000800,
+	STKERR		= 0x00001000,
+	BFARVALID	= 0x00008000,
+	UNDEFINSTR	= 0x00010000,
+	INVSTATE	= 0x00020000,
+	INVPC		= 0x00040000,
+	NOCP		= 0x00080000,
+	UNALIGNED	= 0x01000000,
+	DIVBYZERO	= 0x02000000,
+};
+
+enum hard_fault_status_bits {
+	VECTTBL		= 0x00000002,
+	FORCED		= 0x40000000,
+};
+
+enum interrupts {
+	HARDFAULT	= 3,
+	BUSFAULT	= 5,
+	USAGEFAULT	= 6,
+};
+
+struct traps {
+	char	*name;
+	int	test_bit;
+	int	handler;
+};
+
+static struct traps traps[] = {
+	{"Vector Read error",		VECTTBL,	HARDFAULT},
+	{"uCode stack push error",	STKERR,		BUSFAULT},
+	{"uCode stack pop error",	UNSTKERR,	BUSFAULT},
+	{"Escalated to Hard Fault",	FORCED,		HARDFAULT},
+	{"Pre-fetch error",		IBUSERR,	BUSFAULT},
+	{"Precise data bus error",	PRECISERR,	BUSFAULT},
+	{"Imprecise data bus error",	IMPRECISERR,	BUSFAULT},
+	{"No Coprocessor",		NOCP,		USAGEFAULT},
+	{"Undefined Instruction",	UNDEFINSTR,	USAGEFAULT},
+	{"Invalid ISA state",		INVSTATE,	USAGEFAULT},
+	{"Return to invalid PC",	INVPC,		USAGEFAULT},
+	{"Illegal unaligned access",	UNALIGNED,	USAGEFAULT},
+	{"Divide By 0",			DIVBYZERO,	USAGEFAULT},
+	{NULL}
+};
+
+extern void show_regs(struct pt_regs * regs);
+
+/*
+ * The function initializes Bus fault and Usage fault exceptions,
+ * forbids unaligned data access and division by 0.
+ */
+void traps_v7m_init(void){
+	writel(readl(&NVIC->system_handler_csr) | USGFAULTENA | BUSFAULTENA,
+			&NVIC->system_handler_csr);
+	writel(
+#ifndef CONFIG_ARM_V7M_NO_UNALIGN_TRP
+		UNALIGN_TRP |
+#endif
+		DIV_0_TRP | readl(&NVIC->config_control),
+			&NVIC->config_control);
+}
+
+/*
+ * The function prints information about the reason of the exception
+ * @param name		name of current executable (process or kernel)
+ * @param regs		state of registers when the exception occurs
+ * @param in		IPSR, the number of the exception
+ * @param addr		address caused the interrupt, or current pc
+ * @param hstatus	status register for hard fault
+ * @param lstatus	status register for local fault
+ */
+static void traps_v7m_print_message(char *name, struct pt_regs *regs,
+		enum interrupts in, unsigned long addr,
+		unsigned long hstatus, unsigned long lstatus)
+{
+	int i;
+	printk("\n\n%s: fault at 0x%08lx [pc=0x%08lx, sp=0x%08lx]\n",
+			name, addr, instruction_pointer(regs), regs->ARM_sp);
+	for (i = 0; traps[i].name != NULL; ++i) {
+		if ((traps[i].handler == HARDFAULT ? hstatus : lstatus)
+				& traps[i].test_bit) {
+			printk("%s\n", traps[i].name);
+		}
+	}
+	printk("\n");
+}
+
+/*
+ * Common routine for high-level exception handlers.
+ * @param regs		state of registers when the exception occurs
+ * @param in		IPSR, the number of the exception
+ */
+void traps_v7m_common(struct pt_regs *regs, enum interrupts in)
+{
+	unsigned long hstatus;
+	unsigned long lstatus;
+	unsigned long addr;
+
+	hstatus = readl(&NVIC->hard_fault_status);
+	lstatus = readl(&NVIC->local_fault_status);
+
+	if (lstatus & BFARVALID && (in == BUSFAULT ||
+			(in == HARDFAULT && hstatus & FORCED))) {
+		addr = readl(&NVIC->bfar);
+	} else {
+		addr = instruction_pointer(regs);
+	}
+
+	writel(hstatus, &NVIC->hard_fault_status);
+	writel(lstatus, &NVIC->local_fault_status);
+
+#if defined(CONFIG_VFPM)
+	if (lstatus & NOCP) {
+		extern int vfpm_handle_exception(void);
+		if (vfpm_handle_exception()) {
+			return;
+		}
+	}
+#endif
+
+	if (user_mode(regs)) {
+#if defined(CONFIG_DEBUG_USER)
+		extern unsigned int user_debug;
+
+		if (user_debug & UDBG_SEGV) {
+			traps_v7m_print_message(current->comm, regs, in, addr,
+					hstatus, lstatus);
+		}
+#endif
+		if (lstatus & UNDEFINSTR) {
+			send_sig(SIGTRAP, current, 0);
+		}
+		else {
+			send_sig(SIGSEGV, current, 0);
+		}
+	} else {
+		traps_v7m_print_message("KERNEL", regs, in, addr,
+				hstatus, lstatus);
+		show_regs(regs);
+		panic(0);
+	}
+}
+
+/*
+ * High-level exception handler for exception 3 (Hard fault).
+ * @param regs		state of registers when the exception occurs
+ */
+asmlinkage void __exception_irq_entry do_hardfault(struct pt_regs *regs)
+{
+	traps_v7m_common(regs, HARDFAULT);
+}
+
+/*
+ * High-level exception handler for exception 5 (Bus fault).
+ * @param regs		state of registers when the exception occurs
+ */
+asmlinkage void __exception_irq_entry do_busfault(struct pt_regs *regs)
+{
+	traps_v7m_common(regs, BUSFAULT);
+}
+
+/*
+ * High-level exception handler for exception 6 (Usage fault).
+ * @param regs		state of registers when the exception occurs
+ */
+asmlinkage void __exception_irq_entry do_usagefault(struct pt_regs *regs)
+{
+	traps_v7m_common(regs, USAGEFAULT);
+}
+

--- a/arch/arm/kernel/vfp-m.c
+++ b/arch/arm/kernel/vfp-m.c
@@ -1,0 +1,163 @@
+/*
+ * arch/arm/kernel/vfp-m.c
+ *
+ * Copyright (C) 2018 Christer Weinigel <christer@weinigel.se>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/io.h>
+
+#include <asm/thread_notify.h>
+#include <asm/v7m.h>
+#include <asm/vfp.h>
+#include <asm/exception.h>
+
+#define FPCCR		((u32 *)0xe000ef34)	/* Floating-point Context Control Register */
+#define FPCCR_ASPEN	(1 << 31)	/* Enable FPU stacking */
+#define FPCCR_LSPEN	(1 << 30)	/* Enable lazy FPU stacking */
+#define FPCCR_LSPACT	(1 << 0)	/* 1 => Deferred (lazy) FPU stacking is waiting to be saved */
+
+#define FPCAR		((u32 *)0xe000ef38)	/* Floating-point Context Address Register */
+
+#define CPACR		((u32 *)0xe000ed88)	/* Coprocessor Access Control Register */
+#define CPACR_CP0_FULL	(0x3 << 20)	/* Full access to coprocessor 0 */
+#define CPACR_CP1_FULL	(0x3 << 22)	/* Full access to coprocessor 1 */
+
+#undef MVFR0
+#define MVFR0		((u32 *)0xe000ef40)	/* Media and VFP Feature Register 0 */
+
+static struct thread_info *vfpm_last_thread;
+
+static void vfpm_disable_access(void)
+{
+	writel(readl(CPACR) & ~(CPACR_CP0_FULL | CPACR_CP1_FULL), CPACR);
+}
+
+static void vfpm_enable_access(void)
+{
+	writel(readl(CPACR) | CPACR_CP0_FULL | CPACR_CP1_FULL, CPACR);
+}
+
+static void vfpm_save_context(union vfp_state *vfp)
+{
+	u32 dummy;
+	asm volatile("  stc     p11, cr0, [%0], #32*4"
+		     : "=r" (dummy) : "0" (vfp->hard.fpregs) : "cc");
+	asm("	fmrx %0, fpscr"
+	    : "=r" (vfp->hard.fpscr) : : "cc");
+}
+
+static void vfpm_load_context(union vfp_state *vfp)
+{
+	u32 dummy;
+	asm volatile("  ldc     p11, cr0, [%0], #32*4"
+		     : "=r" (dummy) : "0" (vfp->hard.fpregs) : "cc");
+	asm("	fmxr fpscr, %0"
+	    : : "r" (vfp->hard.fpscr) : "cc");
+}
+
+static void vfpm_switch_to(struct thread_info *thread)
+{
+	vfpm_enable_access();
+
+	if (vfpm_last_thread != thread) {
+		if (vfpm_last_thread)
+			vfpm_save_context(&vfpm_last_thread->vfpstate);
+
+		vfpm_load_context(&thread->vfpstate);
+		vfpm_last_thread = thread;
+	}
+}
+
+int vfpm_handle_exception(void)
+{
+	struct thread_info *thread = current_thread_info();
+
+	if ((readl(MVFR0) & 0xf0) != 0x20)
+		return 0;
+
+	WARN_ON(thread->vfpstate.hard.used);
+
+	thread->vfpstate.hard.used = 1;
+	vfpm_switch_to(thread);
+
+	return 1;
+}
+
+static int vfpm_notifier(struct notifier_block *self, unsigned long cmd,
+			 void *t)
+{
+	struct thread_info *thread = t;
+	struct thread_info *current_thread = current_thread_info();
+
+	switch (cmd) {
+	case THREAD_NOTIFY_FLUSH:
+		memset(&thread->vfpstate, 0, sizeof(thread->vfpstate));
+		thread->vfpstate.hard.used = 0;
+		/* fallthrough */
+
+	case THREAD_NOTIFY_EXIT:
+		vfpm_disable_access();
+		vfpm_last_thread = NULL;
+		break;
+
+	case THREAD_NOTIFY_SWITCH:
+		if (thread->vfpstate.hard.used)
+			vfpm_switch_to(thread);
+		else
+			vfpm_disable_access();
+
+		break;
+
+	case THREAD_NOTIFY_COPY:
+		if (current_thread->vfpstate.hard.used) {
+			vfpm_save_context(&current_thread->vfpstate);
+
+			thread->vfpstate.hard.used = 1;
+			vfpm_last_thread = thread;
+		} else
+			memset(&thread->vfpstate, 0, sizeof(thread->vfpstate));
+		break;
+	}
+
+	return NOTIFY_DONE;
+}
+
+static struct notifier_block vfpm_notifier_block = {
+	.notifier_call	= vfpm_notifier,
+};
+
+static int __init vfpm_init(void)
+{
+	/* check for single-precision VFP operations */
+	if (((readl(MVFR0) & MVFR0_SP_MASK) >> MVFR0_SP_BIT) != 0x2)
+		return 0;
+
+	printk(KERN_INFO "ARMv7-M VFP coprocessor found\n");
+	if (((readl(MVFR0) & MVFR0_DP_MASK) >> MVFR0_DP_BIT) == 0x2)
+               pr_info("VFP: Double precision floating points are supported\n");
+
+	writel(0, FPCCR);	/* disable state preservation */
+	vfpm_disable_access();
+
+	elf_hwcap |= HWCAP_VFP;
+	thread_register_notifier(&vfpm_notifier_block);
+
+	return 0;
+}
+
+late_initcall(vfpm_init);


### PR DESCRIPTION
Boot Linux on the STM32H753i-EVAL with these changes applied. Run the examples from the float project attached. The unit test will pass if the time of running the check_float_softfp example (hard float) will be far less than  time of running the check_float_soft example.
/tmp # ./check_float_soft
50000000 loops: x=256.000000, y=-256.000000, z=-1099511627776.000000 time spent: 29.657277
/tmp # ./check_float_softfp
50000000 loops: x=256.000000, y=-256.000000, z=-1099511627776.000000 time spent: 1.610669
[float.tar.gz](https://github.com/EmcraftSystems/linux-stm/files/12207146/float.tar.gz)
