### PR TITLE
RM 6805: Reduce debug info in warn_alloc() with no MMU

### DIFF
--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -4360,10 +4360,12 @@ void warn_alloc(gfp_t gfp_mask, nodemask_t *nodemask, const char *fmt, ...)
 			nodemask_pr_args(nodemask));
 	va_end(args);
 
+#ifdef CONFIG_MMU
 	cpuset_print_current_mems_allowed();
 	pr_cont("\n");
 	dump_stack();
 	warn_alloc_show_mem(gfp_mask, nodemask);
+#endif
 }
 
 static inline struct page *


### PR DESCRIPTION
### Design

The memory allocation failure seems to be somewhat expected on systems with no MMU. For example, with our STM32H753I-EVAL BSP, the kernel fails to allocate a contiguous set of pages for the `/lib/libgcc_s.so.1` ramfs node, which is 2694740 bytes in size. This results in the output like this during boot:

```
[    1.471586] kworker/u2:0: page allocation failure: order:10, mode:0x100cc2(GFP_HIGHUSER), nodemask=(null)
[    1.479877] CPU: 0 PID: 8 Comm: kworker/u2:0 Not tainted 6.1.28 #14
[    1.486119] Hardware name: STM32 (Device Tree Support)
[    1.491305] Workqueue: events_unbound async_run_entry_fn
[    1.496562]  unwind_backtrace from show_stack+0xb/0xc
[    1.501622]  show_stack from dump_stack_lvl+0x19/0x1e
[    1.506667]  dump_stack_lvl from warn_alloc+0x5f/0xf8
[    1.511608]  warn_alloc from __alloc_pages+0x375/0x576
[    1.516753]  __alloc_pages from ramfs_nommu_expand_for_mapping+0x61/0x15c
[    1.523550]  ramfs_nommu_expand_for_mapping from ramfs_nommu_setattr+0x41/0x94
[    1.530743]  ramfs_nommu_setattr from notify_change+0x1d7/0x24c
[    1.536603]  notify_change from do_truncate+0x65/0x92
[    1.541662]  do_truncate from vfs_truncate+0x6b/0x92
[    1.546622]  vfs_truncate from do_name+0xad/0x17c
[    1.551273]  do_name from write_buffer+0x15/0x24
[    1.555893]  write_buffer from flush_buffer+0x21/0x60
[    1.560921]  flush_buffer from __gunzip+0x1b9/0x20e
[    1.565857]  __gunzip from gunzip+0x17/0x1c
[    1.569967]  gunzip from unpack_to_rootfs+0x111/0x1b8
[    1.575003]  unpack_to_rootfs from do_populate_rootfs+0xd/0x7c
[    1.580858]  do_populate_rootfs from async_run_entry_fn+0x13/0xa0
[    1.586934]  async_run_entry_fn from process_one_work+0xeb/0x15c
[    1.592918]  process_one_work from worker_thread+0x1ad/0x21c
[    1.598584]  worker_thread from kthread+0x8f/0xa0
[    1.603220]  kthread from ret_from_fork+0x11/0x24
[    1.607939] Exception stack(0xd084bfb0 to 0xd084bff8)
[    1.612943] bfa0:                                     00000000 00000000 00000000 00000000
[    1.621143] bfc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    1.629319] bfe0: 00000000 00000000 00000000 00000000 00000000 00000000
[    1.636224] Mem-Info:
[    1.638158] active_anon:0 inactive_anon:0 isolated_anon:0
[    1.638158]  active_file:0 inactive_file:0 isolated_file:0
[    1.638158]  unevictable:1515 dirty:0 writeback:0
[    1.638158]  slab_reclaimable:39 slab_unreclaimable:392
[    1.638158]  mapped:0 shmem:0 pagetables:0
[    1.638158]  sec_pagetables:0 bounce:0
[    1.638158]  kernel_misc_reclaimable:0
[    1.638158]  free:2944 free_pcp:0 free_cma:0
[    1.674905] Node 0 active_anon:0kB inactive_anon:0kB active_file:0kB inactive_file:0kB unevictable:6060kB isolated(anon):0kB isolated(file):0kB mapped:0kB dirty:0kB writeback:0kB shmem:0kB writeback_tmp:0kB kernel_stack:208kB pagetables:0kB sec_pagetables:0kB all_unreclaimable? no
[    1.699603] Normal free:11776kB boost:0kB min:564kB low:704kB high:844kB reserved_highatomic:0KB active_anon:0kB inactive_anon:0kB active_file:0kB inactive_file:0kB unevictable:6060kB writepending:0kB present:32768kB managed:20148kB mlocked:0kB bounce:0kB free_pcp:0kB local_pcp:0kB free_cma:0kB
[    1.725599] lowmem_reserve[]: 0 0
[    1.728790] Normal: 8*4kB (UME) 8*8kB (UM) 8*16kB (UM) 9*32kB (UME) 8*64kB (UME) 4*128kB (UM) 4*256kB (UME) 4*512kB (UME) 1*1024kB (E) 3*2048kB (UME) 0*4096kB = 11776kB
[    1.743950] 1529 total pagecache pages
[    1.747608] 8192 pages RAM
[    1.750222] 0 pages HighMem/MovableOnly
[    1.754138] 3155 pages reserved
```

We will truncate this warning to only the first string on systems with no MMU.

Note that the `ramfs_nommu_expand_for_mapping()` function fails to "add a contiguous set of pages into a ramfs inode when it's truncated from size 0 on the assumption that it's going to be used for an mmap of shared memory". It is probably not critical, and we are unlikely to improve the memory fragmentation, so big files cannot be mmapped in any case.

### Test

Review the boot log and verify that the warning is truncated:

```
[    1.478415] kworker/u2:0: page allocation failure: order:10, mode:0x100cc2(GFP_HIGHUSER), nodemask=(null)
```
