### PR TITLE
RM 6996: net: stmmac: Re-enable RX clock when resuming from low power mode for STM32H7 the target.

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-stm32.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-stm32.c
@@ -531,6 +531,12 @@ static int stm32mcu_suspend(struct stm32_dwmac *dwmac)
 	return 0;
 }
 
+static void stm32mcu_resume(struct stm32_dwmac *dwmac)
+{
+	clk_prepare_enable(dwmac->clk_tx);
+	clk_prepare_enable(dwmac->clk_rx);
+}
+
 #ifdef CONFIG_PM_SLEEP
 static int stm32_dwmac_suspend(struct device *dev)
 {
@@ -574,6 +580,7 @@ static SIMPLE_DEV_PM_OPS(stm32_dwmac_pm_ops,
 static struct stm32_ops stm32mcu_dwmac_data = {
 	.set_mode = stm32mcu_set_mode,
 	.suspend = stm32mcu_suspend,
+	.resume = stm32mcu_resume,
 };
 
 static struct stm32_ops stm32mp1_dwmac_data = {


### PR DESCRIPTION
Fixed issue that  Ethernet is not working after resuming from the  Low Power Mode issues on STM32H7-SOM.

The error is that the MAC and DMA controller could not be reset in the `stmmac_hw_setup` function due to RX clock is not available on STM32H7 when resuming from the low power mode. Previously the RX clock was restored along with the TX clock in the common function `stm32_dwmac_init`, but there was a change made which disabled restoring the RX clock on resume (refer to commit 6528e02cc9ff7a195e2f81fd422458cefa83ad10). This change is specific to STM32MP1 but since it was made in common code, STM32H7 was affected.

This patch added the new resume function to the `stm32mcu_dwmac_data` to restore clocks for STM32H7 specific case. 

Unit test:
 * configure LAN connection on the STM32H7-SOM, ping an external host
 * issue `echo mem > /sys/power/state` in the target board console to enter LPM
 * press the User1 button to resume from LPM
 * make sure there is no error reported and ping an external host is successful
